### PR TITLE
Update drawer.dart

### DIFF
--- a/lib/widgets/drawer.dart
+++ b/lib/widgets/drawer.dart
@@ -36,6 +36,7 @@ class NowDrawer extends StatelessWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   crossAxisAlignment: CrossAxisAlignment.baseline,
+                  textBaseline: TextBaseline.alphabetic,
                   children: [
                     Image.asset("assets/imgs/now-logo.png"),
                     Padding(


### PR DESCRIPTION
The drawer widget is currently broken because of this requirement for CrossAxisAlignment.baseline being set.  This fix assumes alphabetic intention for the drawer.   

The following assertion was thrown building NowDrawer(dirty, dependencies: [MediaQuery]):
textBaseline is required if you specify the crossAxisAlignment with CrossAxisAlignment.baseline
'package:flutter/src/widgets/basic.dart':
Failed assertion: line 4369 pos 15: 'crossAxisAlignment != CrossAxisAlignment.baseline ||
textBaseline != null'